### PR TITLE
Benchmark tuning so we can get more consistent numbers on HT vs non-HT

### DIFF
--- a/src/main/java/org/threadly/concurrent/benchmark/AbstractSchedulerExecuteBenchmark.java
+++ b/src/main/java/org/threadly/concurrent/benchmark/AbstractSchedulerExecuteBenchmark.java
@@ -19,9 +19,8 @@ public abstract class AbstractSchedulerExecuteBenchmark extends AbstractSchedule
         long startTime = System.currentTimeMillis();
         countArray.incrementAndGet(index);
 
-        while (System.currentTimeMillis() - startTime < THREAD_RUN_TIME) {
-          // spin loop
-        }
+        doThreadWork(startTime);
+        
         getScheduler().execute(this);
       }
     }

--- a/src/main/java/org/threadly/concurrent/benchmark/AbstractSchedulerRecurringBenchmark.java
+++ b/src/main/java/org/threadly/concurrent/benchmark/AbstractSchedulerRecurringBenchmark.java
@@ -1,7 +1,7 @@
 package org.threadly.concurrent.benchmark;
 
 public abstract class AbstractSchedulerRecurringBenchmark extends AbstractSchedulerBenchmark {
-  private static final int SCHEDULE_DELAY = 10;
+  private static final int SCHEDULE_DELAY = 5;
   
   @Override
   protected Runnable makeRunnable(int id) {
@@ -23,12 +23,10 @@ public abstract class AbstractSchedulerRecurringBenchmark extends AbstractSchedu
     @Override
     public void run() {
       if (run) {
-      long startTime = System.currentTimeMillis();
+        long startTime = System.currentTimeMillis();
         countArray.incrementAndGet(index);
         
-        while (System.currentTimeMillis() - startTime < THREAD_RUN_TIME) {
-          // spin loop
-        }
+        doThreadWork(startTime);
       }
     }
     

--- a/src/main/java/org/threadly/concurrent/benchmark/AbstractSchedulerScheduleBenchmark.java
+++ b/src/main/java/org/threadly/concurrent/benchmark/AbstractSchedulerScheduleBenchmark.java
@@ -1,7 +1,7 @@
 package org.threadly.concurrent.benchmark;
 
 public abstract class AbstractSchedulerScheduleBenchmark extends AbstractSchedulerBenchmark {
-  private static final int SCHEDULE_DELAY = 10;
+  private static final int SCHEDULE_DELAY = 5;
   private static final boolean DIFFER_SCHEDULE_TIME = false;
   
   @Override
@@ -29,9 +29,7 @@ public abstract class AbstractSchedulerScheduleBenchmark extends AbstractSchedul
           scheduleDelay = SCHEDULE_DELAY;
         }
         
-        while (System.currentTimeMillis() - startTime < THREAD_RUN_TIME) {
-          // spin loop
-        }
+        doThreadWork(startTime);
         
         getScheduler().schedule(this, scheduleDelay);
       }


### PR DESCRIPTION
With our benchmarks now running on more hardware we see they really gave threadly a massive advantage on hyperthreaded hardware compared to non-hyper threaded hardware.
This changes the benchmarks so that the amount of CPU used on tasks is way less, and thus works the scheduler harder.
This means we have more tasks, that are running for shorter periods.  In the new results threadly still has a definite advantage over java.util, but not as much.  Most importantly the results between HT and non-HT hardware seem to coorelate.
